### PR TITLE
Add zt-bridge-watchdog: auto-recover ZeroTier-stranded containers

### DIFF
--- a/ansible/roles/zt-bridge-watchdog/defaults/main.yml
+++ b/ansible/roles/zt-bridge-watchdog/defaults/main.yml
@@ -1,0 +1,22 @@
+# Each host's ZeroTier bridge IP (172.25.12.0/24 host range). Every host pings
+# the OTHERS from inside each local container's netns; a container that can
+# reach none of them is stranded. Host IPs are used (not container/service
+# endpoints) so the check is independent of whether any service is up.
+zt_host_ips:
+  fcos-1: 172.25.12.1
+  fcos-2: 172.25.12.2
+  fcos-3: 172.25.12.3
+  fbshs1: 172.25.12.4
+
+zt_watchdog_ping_timeout: 2
+zt_watchdog_fail_threshold: 3       # consecutive stranded passes before acting
+zt_watchdog_cooldown_sec: 900       # min seconds between restarts of the same container
+zt_watchdog_grace_sec: 180          # ignore containers (re)started within this window (deploys/upgrades)
+zt_watchdog_interval: "30s"
+zt_watchdog_auto_heal: true
+# If more than this many local containers look stranded at once it's a
+# host-level ZeroTier fault (restart won't help) — alert only, never mass-restart.
+zt_watchdog_max_heal: 5
+# net=host containers (no fbs0 IP) are skipped automatically; add any others
+# that should never be auto-restarted.
+zt_watchdog_exclude: "zerotier-one otel-collector-agent"

--- a/ansible/roles/zt-bridge-watchdog/defaults/main.yml
+++ b/ansible/roles/zt-bridge-watchdog/defaults/main.yml
@@ -1,14 +1,8 @@
-# Each host's ZeroTier bridge IP (172.25.12.0/24 host range). Every host pings
-# the OTHERS from inside each local container's netns; a container that can
-# reach none of them is stranded. Host IPs are used (not container/service
-# endpoints) so the check is independent of whether any service is up.
-zt_host_ips:
-  fcos-1: 172.25.12.1
-  fcos-2: 172.25.12.2
-  fcos-3: 172.25.12.3
-  fbshs1: 172.25.12.4
-
-zt_watchdog_ping_timeout: 2
+# Each host pings the OTHER hosts' ZeroTier IPs (zerotier_host_ip, from
+# host_vars) from inside each local container's netns; a container that reaches
+# none is stranded. Host IPs are used (not service endpoints) so the check is
+# independent of whether any app is up.
+zt_watchdog_ping_timeout: 1
 zt_watchdog_fail_threshold: 3       # consecutive stranded passes before acting
 zt_watchdog_cooldown_sec: 900       # min seconds between restarts of the same container
 zt_watchdog_grace_sec: 180          # ignore containers (re)started within this window (deploys/upgrades)
@@ -17,6 +11,6 @@ zt_watchdog_auto_heal: true
 # If more than this many local containers look stranded at once it's a
 # host-level ZeroTier fault (restart won't help) — alert only, never mass-restart.
 zt_watchdog_max_heal: 5
-# net=host containers (no fbs0 IP) are skipped automatically; add any others
-# that should never be auto-restarted.
-zt_watchdog_exclude: "zerotier-one otel-collector-agent"
+# Extra fbs0 containers to never auto-restart. net=host containers are skipped
+# automatically; zerotier-one is unconditionally excluded in the script.
+zt_watchdog_exclude: "otel-collector-agent"

--- a/ansible/roles/zt-bridge-watchdog/files/zt-bridge-watchdog.sh
+++ b/ansible/roles/zt-bridge-watchdog/files/zt-bridge-watchdog.sh
@@ -32,7 +32,7 @@ FAIL_THRESHOLD="${FAIL_THRESHOLD:-3}"
 COOLDOWN_SEC="${COOLDOWN_SEC:-900}"
 AUTO_HEAL="${AUTO_HEAL:-true}"
 MAX_HEAL="${ZTWD_MAX_HEAL:-5}"
-EXCLUDE="${EXCLUDE:-zerotier-one otel-collector-agent}"
+EXCLUDE="${EXCLUDE:-otel-collector-agent}"
 
 mkdir -p "$STATE_DIR"
 log() { echo "zt-bridge-watchdog: $*"; }

--- a/ansible/roles/zt-bridge-watchdog/files/zt-bridge-watchdog.sh
+++ b/ansible/roles/zt-bridge-watchdog/files/zt-bridge-watchdog.sh
@@ -51,12 +51,18 @@ reaches_a_peer() {
 now=$(date +%s)
 declare -a stranded=()
 
-# Fields are space-separated; the only field that can be empty (no fbs0 IP) is
-# last, so it cannot shift the others. An empty/non-172.25 ip is filtered out.
-while read -r name status started_at pid ip; do
-  case " $EXCLUDE " in *" $name "*) continue ;; esac
+# IP is the last (possibly multi-token) field so it can't shift the others.
+# Docker's network order is not stable, so scan all addresses for the fbs0 one.
+while read -r name status started_at pid ips; do
+  # zerotier-one is hardcoded out: `docker restart zerotier-one` un-enslaves
+  # ztfbs0 and black-holes all cross-host traffic (see incident report).
+  case " zerotier-one $EXCLUDE " in *" $name "*) continue ;; esac
   [ "$status" = running ] || continue
-  case "$ip" in 172.25.*) ;; *) continue ;; esac   # only fbs0-attached
+  ip=""
+  for addr in $ips; do
+    case "$addr" in 172.25.*) ip=$addr; break ;; esac
+  done
+  [ -n "$ip" ] || continue   # only fbs0-attached
   [ "$pid" -gt 0 ] 2>/dev/null || continue
   started=$(date -d "$started_at" +%s 2>/dev/null || echo 0)
   # Skip freshly (re)created containers so deploys/upgrades are not raced.

--- a/ansible/roles/zt-bridge-watchdog/files/zt-bridge-watchdog.sh
+++ b/ansible/roles/zt-bridge-watchdog/files/zt-bridge-watchdog.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Detects and recovers containers stranded on the ZeroTier L2 bridge.
+#
+# Background: incidents/2026-06-01-login-down-postgres-users-api-unreachable-after-fcos-2-reboot.md
+# When a container on the fbs0 bridge is recreated (host reboot / deploy) its
+# MAC can come up without a bridge-route on peer ZeroTier nodes: the container
+# works locally but is isolated cross-host in BOTH directions, while its
+# siblings on the same host are fine. Only `docker restart` of that container
+# fixes it.
+#
+# This runs on each host and checks ITS OWN running containers from inside each
+# container's network namespace — a stranded container cannot reach ANY peer
+# host, a healthy one can. Detection and the `docker restart` are both local; no
+# cross-host SSH and, crucially, no probing of other machines' services: it only
+# pings the neutral peer HOST IPs, so it is agnostic to whether any app is up.
+#
+# Deliberately conservative about acting:
+#   - only RUNNING containers are considered; a stopped service is never started
+#   - containers younger than GRACE_SEC are skipped, so a deploy/upgrade
+#     recreating a container is not raced
+#   - FAIL_THRESHOLD consecutive failures + COOLDOWN_SEC between restarts
+#   - if more than ZTWD_MAX_HEAL containers look stranded at once it's a
+#     host-level ZeroTier fault (restart won't help) — alert only
+
+set -u
+
+PEER_IPS="${PEER_IPS:?space-separated peer host ZT IPs required}"
+STATE_DIR="${STATE_DIR:-/var/lib/zt-bridge-watchdog}"
+PING_TIMEOUT="${PING_TIMEOUT:-2}"
+GRACE_SEC="${GRACE_SEC:-180}"
+FAIL_THRESHOLD="${FAIL_THRESHOLD:-3}"
+COOLDOWN_SEC="${COOLDOWN_SEC:-900}"
+AUTO_HEAL="${AUTO_HEAL:-true}"
+MAX_HEAL="${ZTWD_MAX_HEAL:-5}"
+EXCLUDE="${EXCLUDE:-zerotier-one otel-collector-agent}"
+
+mkdir -p "$STATE_DIR"
+log() { echo "zt-bridge-watchdog: $*"; }
+
+# Healthy if the container can ping ANY peer host. A stranded MAC reaches none
+# (the echo reply cannot be routed back to it); a single down/unreachable peer
+# is tolerated because only one needs to answer.
+reaches_a_peer() {
+  local pid=$1 ip
+  for ip in $PEER_IPS; do
+    nsenter -t "$pid" -n ping -c1 -W "$PING_TIMEOUT" "$ip" >/dev/null 2>&1 && return 0
+  done
+  return 1
+}
+
+now=$(date +%s)
+declare -a stranded=()
+
+# Fields are space-separated; the only field that can be empty (no fbs0 IP) is
+# last, so it cannot shift the others. An empty/non-172.25 ip is filtered out.
+while read -r name status started_at pid ip; do
+  case " $EXCLUDE " in *" $name "*) continue ;; esac
+  [ "$status" = running ] || continue
+  case "$ip" in 172.25.*) ;; *) continue ;; esac   # only fbs0-attached
+  [ "$pid" -gt 0 ] 2>/dev/null || continue
+  started=$(date -d "$started_at" +%s 2>/dev/null || echo 0)
+  # Skip freshly (re)created containers so deploys/upgrades are not raced.
+  [ $((now - started)) -lt "$GRACE_SEC" ] && continue
+
+  state="$STATE_DIR/${name}"
+  fails=0; last_heal=0
+  [ -f "$state" ] && read -r fails last_heal < "$state"
+
+  if reaches_a_peer "$pid"; then
+    [ "$fails" -ne 0 ] && log "RECOVERED $name ($ip)"
+    fails=0
+  else
+    fails=$((fails + 1))
+    log "STRANDED $name ($ip) consecutive=$fails"
+    [ "$fails" -ge "$FAIL_THRESHOLD" ] && stranded+=("$name")
+  fi
+  echo "$fails $last_heal" > "$state"
+done < <(docker ps -q | xargs -r docker inspect \
+           -f '{{.Name}} {{.State.Status}} {{.State.StartedAt}} {{.State.Pid}} {{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' \
+           2>/dev/null | sed 's#^/##')
+
+[ "${#stranded[@]}" -eq 0 ] && exit 0
+
+if [ "${#stranded[@]}" -gt "$MAX_HEAL" ]; then
+  log "ALERT ${#stranded[@]} containers stranded (${stranded[*]}) — host-level ZeroTier fault, not auto-restarting"
+  exit 0
+fi
+
+for name in "${stranded[@]}"; do
+  state="$STATE_DIR/${name}"
+  read -r fails last_heal < "$state"
+  if [ $((now - last_heal)) -lt "$COOLDOWN_SEC" ]; then
+    log "$name in cooldown ($((COOLDOWN_SEC - (now - last_heal)))s left), not restarting"
+    continue
+  fi
+  if [ "$AUTO_HEAL" != "true" ]; then
+    log "ALERT would restart $name (AUTO_HEAL=false)"
+    continue
+  fi
+  log "HEAL docker restart $name"
+  if docker restart "$name"; then
+    echo "0 $now" > "$state"
+  fi
+done

--- a/ansible/roles/zt-bridge-watchdog/handlers/main.yml
+++ b/ansible/roles/zt-bridge-watchdog/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: reload systemd
+  command: systemctl daemon-reload

--- a/ansible/roles/zt-bridge-watchdog/tasks/main.yml
+++ b/ansible/roles/zt-bridge-watchdog/tasks/main.yml
@@ -16,7 +16,7 @@
 
       [Service]
       Type=oneshot
-      Environment="PEER_IPS={{ zt_host_ips | dict2items | rejectattr('key', 'equalto', inventory_hostname) | map(attribute='value') | join(' ') }}"
+      Environment="PEER_IPS={{ groups['fcos'] | difference([inventory_hostname]) | map('extract', hostvars, 'zerotier_host_ip') | join(' ') }}"
       Environment=PING_TIMEOUT={{ zt_watchdog_ping_timeout }}
       Environment=FAIL_THRESHOLD={{ zt_watchdog_fail_threshold }}
       Environment=COOLDOWN_SEC={{ zt_watchdog_cooldown_sec }}

--- a/ansible/roles/zt-bridge-watchdog/tasks/main.yml
+++ b/ansible/roles/zt-bridge-watchdog/tasks/main.yml
@@ -1,0 +1,60 @@
+- name: Install watchdog script
+  copy:
+    src: zt-bridge-watchdog.sh
+    dest: /usr/local/bin/zt-bridge-watchdog.sh
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Install watchdog service
+  copy:
+    content: |
+      [Unit]
+      Description=ZeroTier bridge stranded-container watchdog
+      Requires=docker.service
+      After=docker.service zerotier-one.service
+
+      [Service]
+      Type=oneshot
+      Environment="PEER_IPS={{ zt_host_ips | dict2items | rejectattr('key', 'equalto', inventory_hostname) | map(attribute='value') | join(' ') }}"
+      Environment=PING_TIMEOUT={{ zt_watchdog_ping_timeout }}
+      Environment=FAIL_THRESHOLD={{ zt_watchdog_fail_threshold }}
+      Environment=COOLDOWN_SEC={{ zt_watchdog_cooldown_sec }}
+      Environment=GRACE_SEC={{ zt_watchdog_grace_sec }}
+      Environment=AUTO_HEAL={{ zt_watchdog_auto_heal | string | lower }}
+      Environment=ZTWD_MAX_HEAL={{ zt_watchdog_max_heal }}
+      Environment="EXCLUDE={{ zt_watchdog_exclude }}"
+      ExecStart=/usr/local/bin/zt-bridge-watchdog.sh
+    dest: /etc/systemd/system/zt-bridge-watchdog.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+
+- name: Install watchdog timer
+  copy:
+    content: |
+      [Unit]
+      Description=Run zt-bridge-watchdog on a schedule
+
+      [Timer]
+      OnBootSec=90s
+      OnUnitActiveSec={{ zt_watchdog_interval }}
+
+      [Install]
+      WantedBy=timers.target
+    dest: /etc/systemd/system/zt-bridge-watchdog.timer
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+
+- meta: flush_handlers
+
+- name: Activate watchdog timer
+  systemd:
+    name: zt-bridge-watchdog.timer
+    state: started
+    enabled: yes

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -22,6 +22,8 @@
       tags: otel-collector-agent
       vars:
         otel_collector_agent_image: "{{ deployer_otel_collector_image }}"
+    - role: zt-bridge-watchdog
+      tags: zt-bridge-watchdog
 
 - hosts: fcos-1
   become: yes

--- a/incidents/2026-06-01-login-down-postgres-users-api-unreachable-after-fcos-2-reboot.md
+++ b/incidents/2026-06-01-login-down-postgres-users-api-unreachable-after-fcos-2-reboot.md
@@ -2,8 +2,8 @@
 
 ## Timeline
 
-- **2026-06-01 00:04:06 UTC** — fcos-2 rebooted (Fedora CoreOS / Zincati automatic OS update; previous boot 2026-05-18 22:14). All fcos-2 containers recreated at 00:04:30 with fresh veths/MACs.
 - **2026-05-31 23:53:09 UTC** — last green scheduled `e2e-tests` run.
+- **2026-06-01 00:04:06 UTC** — fcos-2 rebooted (Fedora CoreOS / Zincati automatic OS update; previous boot 2026-05-18 22:14). All fcos-2 containers recreated at 00:04:30 with fresh veths/MACs; three came up stranded.
 - **2026-06-01 01:33:40 UTC** — first failing `e2e-tests` run (first scheduled run after the reboot). Failing hourly thereafter; failing runs took ~21m (retries/timeouts) vs ~3m green.
 - **2026-06-01 ~13:00 UTC** — user reported "unable to login in simplesaml, e2e failing"; investigation started.
 - **2026-06-01 13:38 UTC** — `docker restart postgresql-1 users-api slack-invite-automation` on fcos-2. All three reachable cross-host immediately.

--- a/incidents/2026-06-01-login-down-postgres-users-api-unreachable-after-fcos-2-reboot.md
+++ b/incidents/2026-06-01-login-down-postgres-users-api-unreachable-after-fcos-2-reboot.md
@@ -5,7 +5,7 @@
 - **2026-05-31 23:53:09 UTC** — last green scheduled `e2e-tests` run.
 - **2026-06-01 00:04:06 UTC** — fcos-2 rebooted (Fedora CoreOS / Zincati automatic OS update; previous boot 2026-05-18 22:14). All fcos-2 containers recreated at 00:04:30 with fresh veths/MACs; three came up stranded.
 - **2026-06-01 01:33:40 UTC** — first failing `e2e-tests` run (first scheduled run after the reboot). Failing hourly thereafter; failing runs took ~21m (retries/timeouts) vs ~3m green.
-- **2026-06-01 ~13:00 UTC** — user reported "unable to login in simplesaml, e2e failing"; investigation started.
+- **2026-06-01 ~09:30 UTC** — user reported "unable to login in simplesaml, e2e failing"; investigation started.
 - **2026-06-01 13:38 UTC** — `docker restart postgresql-1 users-api slack-invite-automation` on fcos-2. All three reachable cross-host immediately.
 - **2026-06-01 13:41 UTC** — `intern.spec.ts` login + `api.spec.ts` matmeny pass against prod.
 

--- a/incidents/2026-06-01-login-down-postgres-users-api-unreachable-after-fcos-2-reboot.md
+++ b/incidents/2026-06-01-login-down-postgres-users-api-unreachable-after-fcos-2-reboot.md
@@ -1,0 +1,69 @@
+# 2026-06-01: login (foreningenbs.no) down — postgresql-1 / users-api unreachable across ZeroTier after fcos-2 reboot
+
+## Timeline
+
+- **2026-06-01 00:04:06 UTC** — fcos-2 rebooted (Fedora CoreOS / Zincati automatic OS update; previous boot 2026-05-18 22:14). All fcos-2 containers recreated at 00:04:30 with fresh veths/MACs.
+- **2026-05-31 23:53:09 UTC** — last green scheduled `e2e-tests` run.
+- **2026-06-01 01:33:40 UTC** — first failing `e2e-tests` run (first scheduled run after the reboot). Failing hourly thereafter; failing runs took ~21m (retries/timeouts) vs ~3m green.
+- **2026-06-01 ~13:00 UTC** — user reported "unable to login in simplesaml, e2e failing"; investigation started.
+- **2026-06-01 13:38 UTC** — `docker restart postgresql-1 users-api slack-invite-automation` on fcos-2. All three reachable cross-host immediately.
+- **2026-06-01 13:41 UTC** — `intern.spec.ts` login + `api.spec.ts` matmeny pass against prod.
+
+## Impact
+
+- `foreningenbs.no` login (SAML) broken for ~13.5h: the intern "Logg inn" route queries Postgres, so it 500'd before redirecting to the IdP — the SSP login page never appeared. (SimpleSAMLphp and OpenLDAP themselves were healthy.)
+- matmeny API returned 500 (`write CONNECT_TIMEOUT postgresql-1.zt.foreningenbs.no:5432`).
+- `webdavcgi` (`/filer/`) login failed (same intern/SAML path).
+- `users-api` (auth/user lookups) and `slack-invite-automation` unreachable across hosts.
+- Hourly e2e failing continuously from 01:33 UTC.
+
+## Root cause
+
+Recurrence of the ZeroTier bridge MAC-stranding pattern — see `2026-03-21-confluence-down.md`, `2026-04-26-uka-billett-down.md`, `2026-05-02-filer-503-after-fcos-3-reboot.md`, `2026-05-02-otel-collector-deploy-fbshs1-unreachable.md`.
+
+- **Trigger (this time):** the FCOS auto-reboot recreated all fcos-2 containers simultaneously. Three of them — `postgresql-1` (172.25.16.42), `users-api` (172.25.16.2), `slack-invite-automation` (172.25.16.9) — came up stranded; the rest (`mysql-1`, `ldap-master`, `gatus`, `okoreports-*`, `snipeit`, …) came up fine.
+- **Underlying condition:** containers attach to the `fbs0` Docker bridge, which is L2-bridged to ZeroTier via `ztfbs0`. For a container to be reachable cross-host, peer ZeroTier nodes must hold a bridge-route mapping its MAC to the owner node. ZeroTier does not flood unknown unicast, so a missing route silently black-holes all unicast to that MAC. After a mass recreate, some MACs never get that route installed on peers, and it does not self-heal.
+
+Evidence gathered this time (which the prior reports left as "mechanism not confirmed"):
+
+- On fcos-2, the local bridge state for a stranded container was **identical to a working one**: MAC present in `bridge fdb` on its veth, veth + `ztfbs0` `master fbs0 state forwarding`. Postgres was reachable on `5432` from fcos-2 itself.
+- The peer's cached ARP entry for the stranded container held the **correct current MAC** (`22:86:f6:1d:6e:03`) and was even marked `REACHABLE` — yet TCP timed out. ICMP was intermittently "OK". So ARP/ping are false-green signals.
+- `tcpdump -i ztfbs0` on fcos-2 while a peer probed:
+  - postgres's own gratuitous ARP **egressed** onto ZeroTier.
+  - A fresh broadcast ARP from the peer **reached** fcos-2; postgres's **unicast reply reached the peer** (peer marked `REACHABLE`).
+  - But the peer's subsequent ICMP/TCP unicast to postgres's MAC **never arrived** on fcos-2's `ztfbs0`. The black hole is peer→stranded-MAC unicast only; broadcast and owner→peer unicast both work. It is **per-MAC**, not per-node (mysql, behind the same fcos-2 ZeroTier node, worked throughout).
+- `zerotier-cli` on every node reported healthy: fcos-2↔fcos-3 on a **DIRECT** path, `ONLINE`, controller reachable. `zerotier-cli dump` contains no learned bridge-MAC table. **ZeroTier exposes no signal for this fault.**
+- Owner-side repair levers tried, in order, and their effect on the stranded MACs:
+  - gratuitous ARP from the container — **no effect**.
+  - `ztfbs0` detach/reattach from `fbs0` — **no effect**.
+  - `systemctl restart zerotier-one` on fcos-2 — re-advertised everything and restored `mysql-1`, but the **stranded MACs stayed dead**.
+  - `docker restart <container>` — **fixed it** (fresh veth).
+
+Conclusion: only recreating the container's veth (`docker restart`) reliably clears the stranding. No owner-side network action repairs an already-stranded MAC.
+
+## Resolution
+
+```sh
+ssh root@fcos-2.nrec.foreningenbs.no docker restart postgresql-1 users-api slack-invite-automation
+```
+
+Verify cross-host (from a host that is **not** the owner — local probes always succeed), using each container's real port:
+
+```sh
+# postgresql-1:5432, users-api:8000, slack-invite-automation:3000
+for hp in 172.25.16.42:5432 172.25.16.2:8000 172.25.16.9:3000; do
+  timeout 4 bash -c "</dev/tcp/${hp%:*}/${hp#*:}" && echo "$hp OPEN" || echo "$hp TIMEOUT"
+done
+```
+
+## Observations
+
+- **Do not use `docker restart zerotier-one`.** The container is launched by the `zerotier-one.service` systemd unit, whose `ExecStartPost` re-enslaves `ztfbs0` to `fbs0`. A plain `docker restart` recreates `ztfbs0` **without** that step, leaving it un-enslaved and breaking *all* fcos-2 cross-host traffic. Use `systemctl restart zerotier-one` (it ran the reattach and restored `master fbs0`).
+- **Detection requires a TCP probe from a non-owner host.** Ping, ARP, and `zerotier-cli` all report green during this fault. The probe must use the real service port (TIMEOUT = stranded; refused/CLOSED = reachable-but-not-listening).
+- **Gatus runs on fcos-2 and was blind to this** — it checks fcos-2's own containers locally, where they are always reachable. A monitor co-located with the service it checks cannot see this fault.
+- SimpleSAMLphp's inline OTEL trace export (`OTEL_EXPORTER_OTLP_ENDPOINT=…signoz-otel-collector…:4318`) has been failing since 2026-05-30 (SigNoz/fbshs1 path) and logs a stack trace per request at PHP shutdown. It is post-response (page renders in ~40ms) and was **not** related to this outage — but it is noisy and worth decoupling (export to the local otel-collector-agent, or fail-fast).
+
+## Follow-ups
+
+- Automatic detection + recovery: `ansible/roles/zt-bridge-watchdog/` — a per-host timer that checks each local container from inside its own network namespace (a stranded container reaches no peer host) and `docker restart`s it locally. No cross-host SSH; auto-restarts only a minority of containers (a host-wide failure alerts instead). Closes the gap the prior four reports all recommended ("cross-host container connectivity health check") but never built.
+- Consider eliminating the trigger: re-establish clean bridging after boot/recreate, or order container attach after `ztfbs0` is stably enslaved.


### PR DESCRIPTION
## Why

After fcos-2's 2026-06-01 auto-reboot, `postgresql-1`, `users-api` and `slack-invite-automation` came up **stranded on the ZeroTier L2 bridge** — reachable locally but black-holed cross-host — breaking login (intern→postgres), matmeny and webdavcgi for ~13h. Same class as four prior incidents; only `docker restart` of the container clears it, and nothing local to the owner host could detect it. See `incidents/2026-06-01-login-down-postgres-users-api-unreachable-after-fcos-2-reboot.md`.

## What

`zt-bridge-watchdog` role (per-host systemd timer, runs on all `fcos` hosts):
- From inside each **local running** container's netns, pings the **peer host IPs**. A container reaching no peer is stranded → `docker restart` it **locally** (no SSH, no probing peers' services).
- Guardrails: skips containers younger than `grace_sec` (don't race deploys), `fail_threshold` debounce + `cooldown_sec`, and **alerts instead of mass-restarting** if more than `max_heal` strand at once (host-level fault).

Validated live on fcos-2 (discovery, ICMP probe, grace skip, all-healthy → no action). `auto_heal` defaults to `true`; set `zt_watchdog_auto_heal: false` for a detect-and-log-only rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated host-level watchdog to monitor ZeroTier-connected containers, detect network stalls, and optionally auto-restart affected containers. Includes scheduled checks, configurable thresholds, cooldowns, grace windows, concurrent-heal limits, and a container exclusion list.
* **Documentation**
  * Added a detailed incident report describing a past ZeroTier bridge outage, impact, remediation, and follow-up recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->