### PR TITLE
Fix simplesamlphp build: composer require -W

### DIFF
--- a/services/simplesamlphp/Dockerfile
+++ b/services/simplesamlphp/Dockerfile
@@ -55,9 +55,9 @@ RUN set -eux; \
         {"type": "git", "url": "https://github.com/blindern/simplesamlphp-module-fbs"},\
         {"type": "git", "url": "https://github.com/blindern/simplesamlphp-module-authoauth2"}]' \
       >composer.json; \
-    composer require --ignore-platform-reqs cirrusidentity/simplesamlphp-module-authoauth2 "dev-master#${AUTHOAUTH2_COMMIT}"; \
-    composer require --ignore-platform-reqs blindern/simplesamlphp-module-fbs "dev-master#${FBS_COMMIT}"; \
-    composer require --ignore-platform-reqs \
+    composer require --ignore-platform-reqs --with-all-dependencies cirrusidentity/simplesamlphp-module-authoauth2 "dev-master#${AUTHOAUTH2_COMMIT}"; \
+    composer require --ignore-platform-reqs --with-all-dependencies blindern/simplesamlphp-module-fbs "dev-master#${FBS_COMMIT}"; \
+    composer require --ignore-platform-reqs --with-all-dependencies \
       open-telemetry/sdk \
       open-telemetry/exporter-otlp \
       open-telemetry/opentelemetry-auto-curl \


### PR DESCRIPTION
simplesamlphp image build broke when guzzle 7.15.0 was released: it requires `guzzlehttp/psr7 ^2.13`, but SimpleSAMLphp 2.5.2's lock file pins psr7 2.10.4 and `composer require` without `-W` cannot upgrade locked transitive deps.

Adds `--with-all-dependencies` to the `composer require` calls. Verified image builds locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E35K3FHDua4RWywJohxZ1j

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution during service image builds to help ensure required authentication and telemetry modules are installed reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->