### PR TITLE
Mount backup credentials into mysql containers

### DIFF
--- a/ansible/dugnaden-mysql-backup.yml
+++ b/ansible/dugnaden-mysql-backup.yml
@@ -6,25 +6,8 @@
       set_fact:
         backup_file: "/var/mnt/data/dugnaden-mysql-backup-{{ now(utc=true, fmt='%Y%m%dT%H%M%SZ') }}.sql.xz"
 
-    - name: Copy credentials to host
-      copy:
-        src: "{{ playbook_dir }}/../mysql-dugnaden.cnf"
-        dest: /tmp/ansible-mysqldump-dugnaden-mysql.cnf
-        mode: "0600"
-
-    - name: Copy credentials into container
-      command: docker cp /tmp/ansible-mysqldump-dugnaden-mysql.cnf dugnaden-mysql:/tmp/ansible-mysqldump-dugnaden-mysql.cnf
-
-    - name: Remove credentials from host
-      file:
-        path: /tmp/ansible-mysqldump-dugnaden-mysql.cnf
-        state: absent
-
     - name: Create MySQL backup (mysqldump)
-      shell: "docker exec dugnaden-mysql mysqldump --defaults-extra-file=/tmp/ansible-mysqldump-dugnaden-mysql.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
-
-    - name: Remove credentials from container
-      command: docker exec dugnaden-mysql rm /tmp/ansible-mysqldump-dugnaden-mysql.cnf
+      shell: "docker exec dugnaden-mysql mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
 
     - name: Verify backup file is non-empty
       stat:

--- a/ansible/dugnaden-mysql-backup.yml
+++ b/ansible/dugnaden-mysql-backup.yml
@@ -7,7 +7,9 @@
         backup_file: "/var/mnt/data/dugnaden-mysql-backup-{{ now(utc=true, fmt='%Y%m%dT%H%M%SZ') }}.sql.xz"
 
     - name: Create MySQL backup (mysqldump)
-      shell: "docker exec dugnaden-mysql mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
+      shell: "set -o pipefail; docker exec dugnaden-mysql mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
+      args:
+        executable: /bin/bash
 
     - name: Verify backup file is non-empty
       stat:

--- a/ansible/mysql-1-backup.yml
+++ b/ansible/mysql-1-backup.yml
@@ -7,7 +7,9 @@
         backup_file: "/var/mnt/data/mysql-1-backup-{{ now(utc=true, fmt='%Y%m%dT%H%M%SZ') }}.sql.xz"
 
     - name: Create MySQL backup (mysqldump)
-      shell: "docker exec mysql-1 mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
+      shell: "set -o pipefail; docker exec mysql-1 mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
+      args:
+        executable: /bin/bash
 
     - name: Verify backup file is non-empty
       stat:

--- a/ansible/mysql-1-backup.yml
+++ b/ansible/mysql-1-backup.yml
@@ -6,25 +6,8 @@
       set_fact:
         backup_file: "/var/mnt/data/mysql-1-backup-{{ now(utc=true, fmt='%Y%m%dT%H%M%SZ') }}.sql.xz"
 
-    - name: Copy credentials to host
-      copy:
-        src: "{{ playbook_dir }}/../mysql.cnf"
-        dest: /tmp/ansible-mysqldump-mysql-1.cnf
-        mode: "0600"
-
-    - name: Copy credentials into container
-      command: docker cp /tmp/ansible-mysqldump-mysql-1.cnf mysql-1:/tmp/ansible-mysqldump-mysql-1.cnf
-
-    - name: Remove credentials from host
-      file:
-        path: /tmp/ansible-mysqldump-mysql-1.cnf
-        state: absent
-
     - name: Create MySQL backup (mysqldump)
-      shell: "docker exec mysql-1 mysqldump --defaults-extra-file=/tmp/ansible-mysqldump-mysql-1.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
-
-    - name: Remove credentials from container
-      command: docker exec mysql-1 rm /tmp/ansible-mysqldump-mysql-1.cnf
+      shell: "docker exec mysql-1 mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
 
     - name: Verify backup file is non-empty
       stat:

--- a/ansible/roles/service-dugnaden-mysql/tasks/main.yml
+++ b/ansible/roles/service-dugnaden-mysql/tasks/main.yml
@@ -15,6 +15,15 @@
     mode: 0644
   register: file_copied
 
+- name: Copy backup credentials
+  copy:
+    dest: /var/ansible/dugnaden-mysql/backup.cnf
+    src: "{{ playbook_dir }}/../mysql-dugnaden.cnf"
+    owner: root
+    group: root
+    mode: 0600
+  register: backup_cnf_copied
+
 - name: Get current dugnaden-mysql image info
   docker_image_info:
     name: "{{ dugnaden_mysql_image }}"
@@ -44,8 +53,9 @@
     volumes:
       - /var/mnt/data/dugnaden-mysql-data:/var/lib/mysql:Z
       - /var/ansible/dugnaden-mysql/custom.cnf:/etc/mysql/conf.d/custom.cnf:Z
+      - /var/ansible/dugnaden-mysql/backup.cnf:/etc/mysql/conf.d/backup.cnf:ro,Z
     log_driver: journald
-    restart: "{{ file_copied.changed }}"
+    restart: "{{ file_copied.changed or backup_cnf_copied.changed }}"
     capabilities:
       # https://stackoverflow.com/a/55706057
       - sys_nice

--- a/ansible/roles/service-mysql-1/tasks/main.yml
+++ b/ansible/roles/service-mysql-1/tasks/main.yml
@@ -15,6 +15,15 @@
     mode: 0644
   register: file_copied
 
+- name: Copy backup credentials
+  copy:
+    dest: /var/ansible/mysql-1/backup.cnf
+    src: "{{ playbook_dir }}/../mysql.cnf"
+    owner: root
+    group: root
+    mode: 0600
+  register: backup_cnf_copied
+
 - name: Get current mysql image info
   docker_image_info:
     name: "{{ mysql_1_image }}"
@@ -44,8 +53,9 @@
     volumes:
       - /var/mnt/data/mysql-1-data:/var/lib/mysql:Z
       - /var/ansible/mysql-1/custom.cnf:/etc/mysql/conf.d/custom.cnf:Z
+      - /var/ansible/mysql-1/backup.cnf:/etc/mysql/conf.d/backup.cnf:ro,Z
     log_driver: journald
-    restart: "{{ file_copied.changed }}"
+    restart: "{{ file_copied.changed or backup_cnf_copied.changed }}"
     capabilities:
       # https://stackoverflow.com/a/55706057
       - sys_nice

--- a/ansible/roles/service-snipeit/tasks/main.yml
+++ b/ansible/roles/service-snipeit/tasks/main.yml
@@ -14,6 +14,14 @@
     group: root
     mode: 0644
 
+- name: Copy backup credentials
+  ansible.builtin.copy:
+    dest: /var/ansible/snipeit/backup.cnf
+    src: "{{ playbook_dir }}/../mysql-snipe.cnf"
+    owner: root
+    group: root
+    mode: 0600
+
 - name: download and start mysql
   community.docker.docker_container:
     name: snipe-mysql
@@ -23,6 +31,7 @@
     env_file: /var/ansible/snipeit/.env
     volumes:
       - /var/mnt/data/snipesql-vol:/var/lib/mysql:Z
+      - /var/ansible/snipeit/backup.cnf:/etc/mysql/conf.d/backup.cnf:ro,Z
     networks:
       - name: fbs0
         ipv4_address: "{{ snipe_mysql_ipv4_address }}"

--- a/ansible/roles/service-uka-mysql/tasks/main.yml
+++ b/ansible/roles/service-uka-mysql/tasks/main.yml
@@ -15,6 +15,15 @@
     mode: 0644
   register: file_copied
 
+- name: Copy backup credentials
+  copy:
+    dest: /var/uka-mysql/backup.cnf
+    src: "{{ playbook_dir }}/../mysql-uka.cnf"
+    owner: root
+    group: root
+    mode: 0600
+  register: backup_cnf_copied
+
 - name: Get current uka-mysql image info
   docker_image_info:
     name: "{{ uka_mysql_image }}"
@@ -44,5 +53,6 @@
     volumes:
       - /var/mnt/data/uka-mysql-data:/var/lib/mysql:Z
       - /var/uka-mysql/custom.cnf:/etc/mysql/conf.d/custom.cnf:Z
+      - /var/uka-mysql/backup.cnf:/etc/mysql/conf.d/backup.cnf:ro,Z
     log_driver: journald
-    restart: "{{ file_copied.changed }}"
+    restart: "{{ file_copied.changed or backup_cnf_copied.changed }}"

--- a/ansible/snipe-mysql-backup.yml
+++ b/ansible/snipe-mysql-backup.yml
@@ -7,7 +7,7 @@
         backup_file: "/var/mnt/data/snipe-mysql-backup-{{ now(utc=true, fmt='%Y%m%dT%H%M%SZ') }}.sql.xz"
 
     - name: Create MySQL backup (mysqldump)
-      shell: "docker exec snipe-mysql sh -c 'MYSQL_PWD=$MYSQL_ROOT_PASSWORD mysqldump -uroot --all-databases --single-transaction' | xz > {{ backup_file }}"
+      shell: "docker exec snipe-mysql mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
 
     - name: Verify backup file is non-empty
       stat:

--- a/ansible/snipe-mysql-backup.yml
+++ b/ansible/snipe-mysql-backup.yml
@@ -7,7 +7,9 @@
         backup_file: "/var/mnt/data/snipe-mysql-backup-{{ now(utc=true, fmt='%Y%m%dT%H%M%SZ') }}.sql.xz"
 
     - name: Create MySQL backup (mysqldump)
-      shell: "docker exec snipe-mysql mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
+      shell: "set -o pipefail; docker exec snipe-mysql mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
+      args:
+        executable: /bin/bash
 
     - name: Verify backup file is non-empty
       stat:

--- a/ansible/snipe-mysql-backup.yml
+++ b/ansible/snipe-mysql-backup.yml
@@ -6,25 +6,8 @@
       set_fact:
         backup_file: "/var/mnt/data/snipe-mysql-backup-{{ now(utc=true, fmt='%Y%m%dT%H%M%SZ') }}.sql.xz"
 
-    - name: Copy credentials to host
-      copy:
-        src: "{{ playbook_dir }}/../mysql-snipe.cnf"
-        dest: /tmp/ansible-mysqldump-snipe-mysql.cnf
-        mode: "0600"
-
-    - name: Copy credentials into container
-      command: docker cp /tmp/ansible-mysqldump-snipe-mysql.cnf snipe-mysql:/tmp/ansible-mysqldump-snipe-mysql.cnf
-
-    - name: Remove credentials from host
-      file:
-        path: /tmp/ansible-mysqldump-snipe-mysql.cnf
-        state: absent
-
     - name: Create MySQL backup (mysqldump)
-      shell: "docker exec snipe-mysql mysqldump --defaults-extra-file=/tmp/ansible-mysqldump-snipe-mysql.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
-
-    - name: Remove credentials from container
-      command: docker exec snipe-mysql rm /tmp/ansible-mysqldump-snipe-mysql.cnf
+      shell: "docker exec snipe-mysql sh -c 'MYSQL_PWD=$MYSQL_ROOT_PASSWORD mysqldump -uroot --all-databases --single-transaction' | xz > {{ backup_file }}"
 
     - name: Verify backup file is non-empty
       stat:

--- a/ansible/uka-mysql-backup.yml
+++ b/ansible/uka-mysql-backup.yml
@@ -7,7 +7,9 @@
         backup_file: "/var/mnt/data/uka-mysql-backup-{{ now(utc=true, fmt='%Y%m%dT%H%M%SZ') }}.sql.xz"
 
     - name: Create MySQL backup (mysqldump)
-      shell: "docker exec uka-mysql mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
+      shell: "set -o pipefail; docker exec uka-mysql mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
+      args:
+        executable: /bin/bash
 
     - name: Verify backup file is non-empty
       stat:

--- a/ansible/uka-mysql-backup.yml
+++ b/ansible/uka-mysql-backup.yml
@@ -6,25 +6,8 @@
       set_fact:
         backup_file: "/var/mnt/data/uka-mysql-backup-{{ now(utc=true, fmt='%Y%m%dT%H%M%SZ') }}.sql.xz"
 
-    - name: Copy credentials to host
-      copy:
-        src: "{{ playbook_dir }}/../mysql-uka.cnf"
-        dest: /tmp/ansible-mysqldump-uka-mysql.cnf
-        mode: "0600"
-
-    - name: Copy credentials into container
-      command: docker cp /tmp/ansible-mysqldump-uka-mysql.cnf uka-mysql:/tmp/ansible-mysqldump-uka-mysql.cnf
-
-    - name: Remove credentials from host
-      file:
-        path: /tmp/ansible-mysqldump-uka-mysql.cnf
-        state: absent
-
     - name: Create MySQL backup (mysqldump)
-      shell: "docker exec uka-mysql mysqldump --defaults-extra-file=/tmp/ansible-mysqldump-uka-mysql.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
-
-    - name: Remove credentials from container
-      command: docker exec uka-mysql rm /tmp/ansible-mysqldump-uka-mysql.cnf
+      shell: "docker exec uka-mysql mysqldump --defaults-extra-file=/etc/mysql/conf.d/backup.cnf --all-databases --single-transaction | xz > {{ backup_file }}"
 
     - name: Verify backup file is non-empty
       stat:


### PR DESCRIPTION
Mounts the git-crypted `mysql*.cnf` root credentials read-only at `/etc/mysql/conf.d/backup.cnf` in all four mysql containers (mysql-1, uka-mysql, dugnaden-mysql, snipe-mysql), so mysqldump can run without copying credentials around.

The manual `*-mysql-backup.yml` playbooks are simplified accordingly (docker-cp dance removed). This also enables scheduled nightly dumps of all fbs databases, run from doria (henrist/hsw-iac).

**Note:** each mysql container is recreated once on deploy (new volume mount) — short DB downtime for confluence, UKA billett, snipe-it and dugnaden when merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoxckZXqSLejJWAMEn24Fo